### PR TITLE
Add Persistent Stacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,18 @@ import '@zensen/popup'
 
 By checking your `redux` state, you'll notice an array key under the popup reducer for each instance: `popups`, `overlays`, and `banners`. If a key isn't provided, then that instance's key defaults to `main`, so this works as well:
 
+```js
+
+import '@zensen/popup'
+
+<zen-popup-stack></zen-popup-stack>                <!-- 'main'     -->
+<zen-popup-stack key="popups"></zen-popup-stack>   <!-- 'popups'   -->
+<zen-popup-stack key="overlays"></zen-popup-stack> <!-- 'overlays' -->
+<zen-popup-stack key="banners"></zen-popup-stack>  <!-- 'banners'  -->
+```
+
+This can be useful for apps that need multiple stacks for diverse roles.
+
 If you want to render popups without the blocker, you can add the attribute `hideBlocker`:
 
 ```js
@@ -235,15 +247,3 @@ static get styles() {
 
 <zen-popup-stack class="popup-stack"></zen-popup-stack>
 ```
-
-```js
-
-import '@zensen/popup'
-
-<zen-popup-stack></zen-popup-stack>                <!-- 'main'     -->
-<zen-popup-stack key="popups"></zen-popup-stack>   <!-- 'popups'   -->
-<zen-popup-stack key="overlays"></zen-popup-stack> <!-- 'overlays' -->
-<zen-popup-stack key="banners"></zen-popup-stack>  <!-- 'banners'  -->
-```
-
-This can be useful for apps that need multiple stacks for diverse roles.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,23 @@ If you want to render popups without the blocker, you can add the attribute `hid
 import '@zensen/popup'
 
 <zen-popup-stack hideBlocker></zen-popup-stack>
+```
+
+If you want to change the color of the blocker itself, you can attach a class to the popup stack and manipulate the `--backdrop-color` variable as needed:
+
+```js
+import '@zensen/popup'
+
+static get styles() {
+  return css`
+    .popup-stack {
+      --backdrop-color: blue;
+    }
+  `
+}
+
+<zen-popup-stack class="popup-stack"></zen-popup-stack>
+```
 
 ```js
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zensen/popup",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "license": "MIT",
   "description": "A declarative popup stack for native web components",
   "main": "src/index.js",

--- a/src/popup-stack.js
+++ b/src/popup-stack.js
@@ -64,7 +64,7 @@ export function genComponent (store) {
           grid-area: 1 / 1 / 2 / 2;
         }
 
-        .container[hide] {
+        .blocker[hide] {
           background-color: transparent;
         }
       `
@@ -121,6 +121,10 @@ export function genComponent (store) {
         if (this.key) {
           store.dispatch(register(this.key))
         }
+      }
+
+      if (changedProps.has('__stack')) {
+        this.__open = this.__stack.length > 0
       }
 
       super.update(changedProps)

--- a/src/popup-stack.js
+++ b/src/popup-stack.js
@@ -3,8 +3,6 @@ import { LitElement, html, css } from 'lit-element'
 
 import { register, unregister, pop } from './redux'
 
-export const ID_BLOCKER = 'blocker'
-
 export const CSS_NONE = css`display: none;`
 
 export function genComponent (store) {
@@ -17,17 +15,6 @@ export function genComponent (store) {
           type: Boolean,
           attribute: 'open',
         },
-        __hasPopup: {
-          reflect: true,
-          type: Boolean,
-          attribute: 'haspopup',
-        },
-        __visible: {
-          reflect: true,
-          type: Boolean,
-          attribute: 'visible',
-        },
-
         key: String,
         renderers: Object,
         layout: {
@@ -49,10 +36,11 @@ export function genComponent (store) {
           position: absolute;
           background-color: rgba(0, 0, 0, 0.0);
           transition: background-color 200ms ease-in;
+
           --backdrop-color: rgba(0, 0, 0, 0.5)
         }
 
-        :host([visible]) {
+        :host([open]) {
           top: 0;
           left: 0;
           right: 0;
@@ -79,8 +67,7 @@ export function genComponent (store) {
         .container[hide] {
           background-color: transparent;
         }
-
-              `
+      `
     }
 
     constructor () {
@@ -91,8 +78,6 @@ export function genComponent (store) {
 
     __initState () {
       this.__open = false
-      this.__visible = false
-      this.__hasPopup = false
       this.__stack = []
 
       this.hideBlocker = false
@@ -138,11 +123,6 @@ export function genComponent (store) {
         }
       }
 
-      if (changedProps.has('__stack')) {
-        this.__hasPopup = this.__stack.length > 0
-      }
-
-      this.__visible = this.__hasPopup || this.__open
       super.update(changedProps)
     }
 
@@ -165,7 +145,7 @@ export function genComponent (store) {
       }
 
       return html`
-        <div id="${ID_BLOCKER}${index}" style="z-index: ${index}" class="blocker" ?hide="${hide}">
+        <div style="z-index: ${index}" class="blocker" ?hide="${hide}">
           ${renderer(false, index, this.layout, item.model, this.__handlers.close)}
         </div>
       `

--- a/src/popup-stack.js
+++ b/src/popup-stack.js
@@ -49,10 +49,7 @@ export function genComponent (store) {
           position: absolute;
           background-color: rgba(0, 0, 0, 0.0);
           transition: background-color 200ms ease-in;
-        }
-
-        :host([haspopup]) {
-          /* background-color: rgba(0, 0, 0, 0.5); */
+          --backdrop-color: rgba(0, 0, 0, 0.5)
         }
 
         :host([visible]) {
@@ -67,13 +64,15 @@ export function genComponent (store) {
         }
 
         .container {
+          display: grid;
+          height: 100%;
+        }
+
+        .blocker {
           display: flex;
           align-items: center;
           justify-content: center;
-          /* background-color: transparent; */
-          background-color: rgba(0, 0, 0, 0.5);
-          /* width: 100%; */
-          /* height: 100%; */
+          background-color: var(--backdrop-color);
           grid-area: 1 / 1 / 2 / 2;
         }
 
@@ -81,11 +80,7 @@ export function genComponent (store) {
           background-color: transparent;
         }
 
-        .thing {
-          display: grid;
-          height: 100%;
-        }
-      `
+              `
     }
 
     constructor () {
@@ -170,21 +165,15 @@ export function genComponent (store) {
       }
 
       return html`
-        <div id="${ID_BLOCKER}${index}" style="z-index: ${index}" class="container" ?hide="${hide}">
+        <div id="${ID_BLOCKER}${index}" style="z-index: ${index}" class="blocker" ?hide="${hide}">
           ${renderer(false, index, this.layout, item.model, this.__handlers.close)}
         </div>
       `
     }
 
     render () {
-      // return html`
-      //   <div id="${ID_BLOCKER}" class="container">
-      //     ${this.__stack.map((item, index) => this.__renderItem(item, index))}
-      //   </div>
-      // `
-      //
       return html`
-        <div class="thing">
+        <div class="container">
           ${this.__stack.map((item, index) => this.__renderItem(item, index))}
         </div>
       `

--- a/src/popup-stack.js
+++ b/src/popup-stack.js
@@ -52,7 +52,7 @@ export function genComponent (store) {
         }
 
         :host([haspopup]) {
-          background-color: rgba(0, 0, 0, 0.5);
+          /* background-color: rgba(0, 0, 0, 0.5); */
         }
 
         :host([visible]) {
@@ -70,8 +70,19 @@ export function genComponent (store) {
           display: flex;
           align-items: center;
           justify-content: center;
+          /* background-color: transparent; */
+          background-color: rgba(0, 0, 0, 0.5);
+          /* width: 100%; */
+          /* height: 100%; */
+          grid-area: 1 / 1 / 2 / 2;
+        }
+
+        .container[hide] {
           background-color: transparent;
-          width: 100%;
+        }
+
+        .thing {
+          display: grid;
           height: 100%;
         }
       `
@@ -158,12 +169,22 @@ export function genComponent (store) {
         item.dismiss(new Error('Invalid popup key:', item.key))
       }
 
-      return renderer(hide, index, this.layout, item.model, this.__handlers.close)
+      return html`
+        <div id="${ID_BLOCKER}${index}" style="z-index: ${index}" class="container" ?hide="${hide}">
+          ${renderer(false, index, this.layout, item.model, this.__handlers.close)}
+        </div>
+      `
     }
 
     render () {
+      // return html`
+      //   <div id="${ID_BLOCKER}" class="container">
+      //     ${this.__stack.map((item, index) => this.__renderItem(item, index))}
+      //   </div>
+      // `
+      //
       return html`
-        <div id="${ID_BLOCKER}" class="container">
+        <div class="thing">
           ${this.__stack.map((item, index) => this.__renderItem(item, index))}
         </div>
       `

--- a/test/popup-stack.test.js
+++ b/test/popup-stack.test.js
@@ -34,7 +34,7 @@ describe('popup-stack', () => {
   it('renders', () => expect(instance).to.exist)
 
   it('does not have popups',
-    () => expect(instance.getAttribute('haspopup')).to.not.exist)
+    () => expect(getBlockerElements()).to.be.empty)
 
   it('registers a reducer', () =>
     expect(dispatchSpy.calledWith(register(KEY_MAIN))).to.be.true)

--- a/test/popup-stack.test.js
+++ b/test/popup-stack.test.js
@@ -10,7 +10,7 @@ import { POPUP_MESSAGE, RENDERER_POPUPS } from './utils/popup'
 const KEY_MAIN = 'main'
 const KEY_NOTIFICATIONS = 'notifications'
 
-describe('popup-stack', () => {
+describe.only('popup-stack', () => {
   let sandbox
   let instance
   let dispatchSpy
@@ -74,6 +74,10 @@ describe('popup-stack', () => {
     it('passes model data to the popup', () =>
       expect(popupElem.model).to.eql(MODEL))
 
+    it('has open attribute', () =>
+      expect(instance.hasAttribute('open')).to.be.true
+    )
+
     context('when dismissing the popup', () => {
       let dismissStub
 
@@ -89,6 +93,10 @@ describe('popup-stack', () => {
 
       it('dismisses the popup', () =>
         expect(dismissStub.calledOnce).to.be.true)
+
+      it('removes open attribute', () =>
+        expect(instance.hasAttribute('open')).to.be.false
+      )
     })
 
     context('when another popup is pushed onto the stack', () => {

--- a/test/popup-stack.test.js
+++ b/test/popup-stack.test.js
@@ -10,7 +10,7 @@ import { POPUP_MESSAGE, RENDERER_POPUPS } from './utils/popup'
 const KEY_MAIN = 'main'
 const KEY_NOTIFICATIONS = 'notifications'
 
-describe.only('popup-stack', () => {
+describe('popup-stack', () => {
   let sandbox
   let instance
   let dispatchSpy


### PR DESCRIPTION
Adds functionality for entries in the popup stack to visibly appear on top of one another when multiple popups are opened consecutively.

Changes:

- Added a new css variable, `--backdrop-color`, which controls the color of the backdrop for each popup entry.
- Removed the concepts of `hasPopup` and `visible` since they weren't needed for styling
